### PR TITLE
Implementatie van documentatie omtrent deactiveren van gebruiker accounts

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,6 +41,7 @@ export default defineConfig({
         collapsed: true,
         items: [
             { text: 'Machtigingen', link: '/gebruikers/machtigingen' },
+            { text: 'Account deactivatie', link: '/gebruikers/deactivatie' }
         ]
       },
 

--- a/docs/gebruikers/deactivatie.md
+++ b/docs/gebruikers/deactivatie.md
@@ -1,0 +1,101 @@
+# Deactiveren en reactiveren van accounts bij scheinding van gebruikersvoorwaarden
+
+We vinden het belangrijk dat het Vlaams Woordenboek een veilighe, eerlijke en prettige plek is voor iedereen. 
+In dithandleidingsdocument legge we duidelijk uit wat er gebeurt als iemand de gebruikersvoorwaarden schendt.
+OOk lees je hoe je je account weer kunt terugkrijgen als het (tijdelijk) is gedeactiveerd. 
+
+Of je nu per ongelijk iets fout hebt gedaan of te maken hebt met een misverstand, we zorgen voor een duidelijke communicatielijn en eerlijke procedures. 
+
+## Wanneer wordt een account gedeactiveerd? 
+
+Wanneer een gebruiker zich niet houdt aan de gebruikersvoorwaarden, kunnen we besluiten het account (tijdelijk of permanent) te deactiveren. 
+Dit doen we om de veiligheid, integriteit en het wederzijds respect op ons platform te waarborgen. 
+De beslissing om een account te deactiveren nemen we zorgvuldig en op basis van duidelijke criteria. 
+In de volgende secties leggen we uit waarom, wanneer en hoe een account gedeactiveerd kan worden.
+
+### Redenen voor deactivering. 
+
+Je account kan (tijdelijk of permanent) wordfen gedeactiveerd als jij je niet aan de gebruikersvoorwaarden houdt. 
+Voorbeelden hiervan zijn: 
+
+- Het plaasten van aanstootgevende, geweldadige of discriminerende inhoud buiten de context van een woordenboek artikel. 
+- Het lastigvallen, intimideren of bedreigen van andere gebruikers. 
+- Spam of ongewenste reclame verspreiden via het meldings of suggestie formulier. 
+- Inbreuk maken op autheursrechten of andermans creatief werk zonder toestemming. 
+- Zich voordoen als iemand anders of misleiding van andere gebruikers. 
+- Pogingen tot hacking of ongewesnt manipuleren van de website. 
+- Elke andere handeling die in strijd is mett onze regels of de veiligheid van anderen schaadt. 
+
+We nemen deze zaken serieus, omdat ze de ervaring van andere gebruikers beinvloeden. 
+
+### Hoe verloopt de deactiveringsprocedure? 
+
+#### 1. Melding of schade 
+
+Overtredingen kunnen worden gemeld door andere gebruikers of authomatisch worden opgespoord. Daarnaast controleren beheerders ook op willekeurige tijdstippen op misbruik. 
+
+#### 2. Onderzoek omtrent de inbreuk 
+
+Elke melding wordt zorgvuldig bekeken en op basis daarvan beoordelen we of de mogelijkse overtreding(en) ernstig genoeg zijn voor een deactivatie van het account in kwestie. 
+
+#### 3. Waarschuwing (indien van toepassing)
+
+Bij een lichte of eerste overtreding krijg je meestal eerst een waarschuwing in de vorm van een deactivatie die meestal maar enkele dagen duurt. 
+
+### 4. Deactivering 
+
+Bij herhaalde of ernstige overtredingen schakelen we je account tijdelijk uit voor meerdere weken of kunnen we besluiten dat een verwijdering van het account op zijn plaats is. 
+
+### Wat zijn de gevolgen van een deactivering? 
+
+Als je account is gedeactiveerd: 
+
+- Kun je niet meer inloggen of deelnemen aan de community binnen het platform van het Vlaams Woordenboek. 
+- Kunnen eerder geplaatste berichten en of inhoud worden verwijderd. 
+- In ernstige gevallen kan verdere actie volgen, bijvoorbeeld juridische stappen. 
+
+We nemen deze stappen niet lichtvoetig en zorgen altijd voor een goede onderbouwing. 
+
+## Kan mijn account worden hersteld? 
+
+Ja in sommige gevallen kun je een gedactiveerd account laten heractiveren. We leggen hieronder uit wanneer dat mogelijk is en wat je ervoor moet doen. 
+
+### Wanneer is reactivering mogelijk? 
+
+We overwegen een heractivering van je account als je voldoet aan een van de volgende criteria:
+
+- Je denkt dat je account ontrecht is gedeactiveerd (bijvoorbeeld een misverstand of fout in ons systeem). 
+- Je erkent de overtreding, toont begrip, en geeft aan dat je de regels voortaan zulpt naleven. 
+- Het om een lichte of eerste overtreding ging. 
+
+### Hoe werkt het reactiveringsproces? 
+
+#### 1. Indien van een verzoek 
+
+Stuur een e-mail of gebruik het contactformulier met je gebruikersnaam, een korte uitleg van de situatie, en waarom je vindt dat je account moet worden hersteld.
+
+#### 2. Beoordeling door ons team van beheerders 
+
+Moderators en of beheerders bekijken je verzoek zorgvuldig. En even je binnen een redelijk termijn uitsluitsel omtrent de beslissing die genomen is. 
+
+#### 3. Reactivering (indien goedgekeurd)
+
+Als we je verzoek goedkeuren, activeren we je account opnieuw. 
+Let wel op in sommige gevallen stellen we voorwaarden, zoals het volgen van richtlijnen of het herkennen van de gedragscode. 
+
+#### 4. Terugkoppeling 
+
+Je krijgt een duidelijke e-mail met de uitkomst en indien van toepassing instructies. 
+
+### Wat môet je verder weten? 
+
+- **Lees de gebruikersvoorwaarden goed door.** Je vindt ze [hier]() op onze website. 
+- **Iedereen is verantwoordelijk voor zijn of haar gedrag op het platform (Vlaams Woordenboek)**
+- **Herhaalde of ernstige overtredingen kunnen leiden tot definitieve uitsluiting.**
+- **De beslissing van de beheerders is in principe bindend,** maar we staan altijd open voor constructieve feedback.
+
+## Hulp of vragen? 
+
+Heb je vragen over deze procedures? Of wil je je situatie toelichten? Neem dan gerust contact op met ons ondersteuningsteam via [e-mail] of het contactformulier op de website.
+
+We staan klaar om je te helpen — ook als er iets is misgegaan.

--- a/docs/gebruikers/deactivatie.md
+++ b/docs/gebruikers/deactivatie.md
@@ -1,98 +1,98 @@
-# Deactiveren en reactiveren van accounts bij scheinding van gebruikersvoorwaarden
+# Deactiveren en heractiveren van accounts bij scheiding van gebruikersvoorwaarden
 
-We vinden het belangrijk dat het Vlaams Woordenboek een veilighe, eerlijke en prettige plek is voor iedereen. 
-In dithandleidingsdocument legge we duidelijk uit wat er gebeurt als iemand de gebruikersvoorwaarden schendt.
-OOk lees je hoe je je account weer kunt terugkrijgen als het (tijdelijk) is gedeactiveerd. 
+We vinden het belangrijk dat het Vlaams Woordenboek een veilige, eerlijke en prettige plek is voor iedereen. 
+In dit handleidingsdocument leggen we duidelijk uit wat er gebeurt als iemand de gebruikersvoorwaarden schendt.
+Je leest ook hoe je je account weer kunt terugkrijgen als het (tijdelijk) is gedeactiveerd. 
 
-Of je nu per ongelijk iets fout hebt gedaan of te maken hebt met een misverstand, we zorgen voor een duidelijke communicatielijn en eerlijke procedures. 
+Of je nu per ongeluk iets fout hebt gedaan of er sprake is van een misverstand, we zorgen voor een duidelijke communicatielijn en eerlijke procedures. 
 
 ## Wanneer wordt een account gedeactiveerd? 
 
-Wanneer een gebruiker zich niet houdt aan de gebruikersvoorwaarden, kunnen we besluiten het account (tijdelijk of permanent) te deactiveren. 
+Wanneer een gebruiker zich niet houdt aan de gebruikersvoorwaarden, kunnen we besluiten het account tijdelijk of permanent te deactiveren. 
 Dit doen we om de veiligheid, integriteit en het wederzijds respect op ons platform te waarborgen. 
 De beslissing om een account te deactiveren nemen we zorgvuldig en op basis van duidelijke criteria. 
 In de volgende secties leggen we uit waarom, wanneer en hoe een account gedeactiveerd kan worden.
 
 ### Redenen voor deactivering. 
 
-Je account kan (tijdelijk of permanent) wordfen gedeactiveerd als jij je niet aan de gebruikersvoorwaarden houdt. 
+Je account kan (tijdelijk of permanent) worden gedeactiveerd als jij je niet aan de gebruikersvoorwaarden houdt. 
 Voorbeelden hiervan zijn: 
 
-- Het plaasten van aanstootgevende, geweldadige of discriminerende inhoud buiten de context van een woordenboek artikel. 
+- Het plaatsen van aanstootgevende, gewelddadige of discriminerende inhoud buiten de context van een woordenboekartikel. 
 - Het lastigvallen, intimideren of bedreigen van andere gebruikers. 
-- Spam of ongewenste reclame verspreiden via het meldings of suggestie formulier. 
-- Inbreuk maken op autheursrechten of andermans creatief werk zonder toestemming. 
+- Spam of ongewenste reclame verspreiden via het meldings- of suggestieformulier. 
+- Inbreuk maken op auteursrechten of gebruik maken van andermans creatief werk zonder toestemming. 
 - Zich voordoen als iemand anders of misleiding van andere gebruikers. 
-- Pogingen tot hacking of ongewesnt manipuleren van de website. 
-- Elke andere handeling die in strijd is mett onze regels of de veiligheid van anderen schaadt. 
+- Pogingen tot hacking of ongewenst manipuleren van de website. 
+- Elke andere handeling die in strijd is met onze regels of de veiligheid van anderen schaadt. 
 
-We nemen deze zaken serieus, omdat ze de ervaring van andere gebruikers beinvloeden. 
+We nemen deze zaken serieus, omdat ze de ervaring van andere gebruikers beïnvloeden. 
 
 ### Hoe verloopt de deactiveringsprocedure? 
 
 #### 1. Melding of schade 
 
-Overtredingen kunnen worden gemeld door andere gebruikers of authomatisch worden opgespoord. Daarnaast controleren beheerders ook op willekeurige tijdstippen op misbruik. 
+Overtredingen kunnen worden gemeld door andere gebruikers of automatisch worden opgespoord. Daarnaast controleren beheerders op willekeurige tijdstippen op misbruik. 
 
 #### 2. Onderzoek omtrent de inbreuk 
 
-Elke melding wordt zorgvuldig bekeken en op basis daarvan beoordelen we of de mogelijkse overtreding(en) ernstig genoeg zijn voor een deactivatie van het account in kwestie. 
+We onderzoeken elke melding zorgvuldig en beslissen op basis daarvan of de mogelijkse overtreding(en) ernstig genoeg zijn voor een deactivatie van het account in kwestie. 
 
 #### 3. Waarschuwing (indien van toepassing)
 
-Bij een lichte of eerste overtreding krijg je meestal eerst een waarschuwing in de vorm van een deactivatie die meestal maar enkele dagen duurt. 
+Bij een lichte of eerste overtreding krijg je meestal eerst een waarschuwing in de vorm van een deactivatie van slechts enkele dagen. 
 
 ### 4. Deactivering 
 
-Bij herhaalde of ernstige overtredingen schakelen we je account tijdelijk uit voor meerdere weken of kunnen we besluiten dat een verwijdering van het account op zijn plaats is. 
+Bij herhaalde of ernstige overtredingen schakelen we je account uit voor meerdere weken of kunnen we besluiten dat het account verwijderd wordt. 
 
 ### Wat zijn de gevolgen van een deactivering? 
 
 Als je account is gedeactiveerd: 
 
-- Kun je niet meer inloggen of deelnemen aan de community binnen het platform van het Vlaams Woordenboek. 
-- Kunnen eerder geplaatste berichten en of inhoud worden verwijderd. 
+- Kan je niet meer inloggen of deelnemen aan de community binnen het platform van het Vlaams Woordenboek. 
+- Kunnen eerder geplaatste berichten en/of inhoud van jou worden verwijderd. 
 - In ernstige gevallen kan verdere actie volgen, bijvoorbeeld juridische stappen. 
 
-We nemen deze stappen niet lichtvoetig en zorgen altijd voor een goede onderbouwing. 
+We nemen deze stappen weloverwogen en zorgen altijd voor een goede onderbouwing. 
 
 ## Kan mijn account worden hersteld? 
 
-Ja in sommige gevallen kun je een gedactiveerd account laten heractiveren. We leggen hieronder uit wanneer dat mogelijk is en wat je ervoor moet doen. 
+Ja in sommige gevallen kun je een gedactiveerd account laten heractiveren. We leggen hieronder uit in welke gevallen dat mogelijk is en wat je ervoor moet doen. 
 
-### Wanneer is reactivering mogelijk? 
+### Wanneer is heractivering mogelijk? 
 
 We overwegen een heractivering van je account als je voldoet aan een van de volgende criteria:
 
-- Je denkt dat je account ontrecht is gedeactiveerd (bijvoorbeeld een misverstand of fout in ons systeem). 
-- Je erkent de overtreding, toont begrip, en geeft aan dat je de regels voortaan zulpt naleven. 
-- Het om een lichte of eerste overtreding ging. 
+- Het gaat om een lichte of eerste overtreding.
+- Je denkt dat je account onterecht is gedeactiveerd (bijvoorbeeld een misverstand of fout in ons systeem) en je kunt dat aantonen of beargumenteren. 
+- Je erkent de overtreding, toont begrip, en geeft aan dat je de regels voortaan zult naleven. 
 
-### Hoe werkt het reactiveringsproces? 
+### Hoe werkt het heractiveringsproces? 
 
-#### 1. Indien van een verzoek 
+#### 1. Een verzoek indienen
 
 Stuur een e-mail of gebruik het contactformulier met je gebruikersnaam, een korte uitleg van de situatie, en waarom je vindt dat je account moet worden hersteld.
 
 #### 2. Beoordeling door ons team van beheerders 
 
-Moderators en of beheerders bekijken je verzoek zorgvuldig. En even je binnen een redelijk termijn uitsluitsel omtrent de beslissing die genomen is. 
+Moderators en beheerders bekijken je verzoek zorgvuldig en geven je binnen een redelijk termijn uitsluitsel omtrent de genomen beslissing. 
 
 #### 3. Reactivering (indien goedgekeurd)
 
-Als we je verzoek goedkeuren, activeren we je account opnieuw. 
-Let wel op in sommige gevallen stellen we voorwaarden, zoals het volgen van richtlijnen of het herkennen van de gedragscode. 
+Als we je verzoek goedkeuren, activeren we je account weer. 
+Let wel, in sommige gevallen stellen we voorwaarden, zoals het volgen van richtlijnen of het erkennen van de gedragscode. 
 
 #### 4. Terugkoppeling 
 
-Je krijgt een duidelijke e-mail met de uitkomst en indien van toepassing instructies. 
+Je krijgt een duidelijke e-mail met het resultaat en instructies indien nodig. 
 
-### Wat môet je verder weten? 
+### Wat moet je verder weten? 
 
 - **Lees de gebruikersvoorwaarden goed door.** Je vindt ze [hier]() op onze website. 
 - **Iedereen is verantwoordelijk voor zijn of haar gedrag op het platform (Vlaams Woordenboek)**
 - **Herhaalde of ernstige overtredingen kunnen leiden tot definitieve uitsluiting.**
-- **De beslissing van de beheerders is in principe bindend,** maar we staan altijd open voor constructieve feedback.
+- **De beslissing van de beheerders is in principe bindend,** maar we staan altijd open voor heldere argumentatie en constructieve feedback.
 
 ## Hulp of vragen? 
 


### PR DESCRIPTION
In deze Pull request voegen we een eerste opzet toe voor het documentatie document dat gaat over de deactivatie van gebruikersaccounts. 

Proof-read mag altijd. Indien deze opzet ok is kunnen we deze mergen en verder implementeren in de back-end van het Vlaams Woordenboek. Anders voeren we de nodige aanpassingen nog uit tot het de gewenste standaard behaald. 