### PR TITLE
Toevoegen voor documentatie van het labelsysteem voor woordenboek artikelen. 

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,6 +37,7 @@ export default withMermaid({
         link: '/artikelen',
         items: [
           { text: 'Levenscyclus', link: '/artikelen/levenscyclus' },
+          { text: 'Labelsysteem', link: '/artikelen/labelsysteem' },
         ]
       },
       {

--- a/docs/artikelen/labelsysteem.md
+++ b/docs/artikelen/labelsysteem.md
@@ -1,0 +1,73 @@
+# Labelsysteem van het Vlaams Woordenboek 
+
+Het labelsysteem is een kernonderdeel van het Vlaams woordenboek. 
+Het helpt om woorden niet alleen te beschrijven, maar ook te kaderen in gebruik, toon, plaats en tijd.
+Deze documentatie is er voor idereen die aan het woordenboek meewerkt: redacteurs, eindredacteurs, administrators en ontwikkelaars. 
+Het doel is helderheid en uniformiteit in het gebruik van labels, zodat de inhoud betouwbaar en bruikbaar blijft. 
+
+## Wat doet het labelsysteem? 
+
+Met labels geef je extra informatie over een woord. 
+Ze kunnen aanduiden of een woord formeel of informeel is, typisch voor een bepaalde regio, vooral vroeger gebruikt werd, of specifiek is voor een bepaald vakgebied. 
+Ook de gebruikssituatie zoals ironisch of kindertaal kan gelabeld worden. Een woord mag gerust meerdere lebels tegelijk krijgen. 
+
+## Wie mag wat? 
+
+Hieronder zie je welke rechten hebben binnen het beheer van het labelsysteem: 
+
+|                   | Toevoegen          | Aanpassen          | Koppelen              | Ontkoppelen        | Verwijderen        | 
+| :---------------- | :----------------: | :----------------: | :-------------------: | :----------------: | :----------------: | 
+| **Redacteur**     | :x:                | :x:                | :heavy_check_mark:    | :heavy_check_mark: | :x:                |
+| **Eindredacteur** | :x:                | :x:                | :heavy_check_mark:    | :heavy_check_mark: | :x:                |
+| **Administrator** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark: |
+| **Ontwikkelaar**  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark: | :heavy_check_mark: |
+
+## Hoe labels toevoegen aan een artikel? 
+
+Als je een woord invoert of bewerkt, zie je een veld 'Labels'. Je kunt daar typen om een label te zoeken, of een selectie maken uit de lijst.
+Geselecteerde labels verschijnen als visuele 'badges'.
+Je kunt ze eenvoudig verwijderen met een klik op het kruisje. 
+Als alles klaar is, kklik je op "Oplsaan", "Bevestigen" op "Volgende". 
+
+## Voorbeelden in de interface 
+
+- **Invoerinterface**: bij het woord "bakske" (auto) zie je bijvoorbeeld de labels *informeel, dialect* en *West-Vlaams* verschijnen. 
+- **Publieke weergave**: het woord krijgt de labels te zien onder de betekenis.
+- **Beheersconsole:** eindredacteurs en admins kunnen daar labels beheren: aanpassen, toelichten, aantal toepassen bekijken + de bijhorende beschrijving. 
+
+### Voorbeeldlabels 
+
+Hieronder een overzicht van enkele voorbeeldlabels ter illustratie en hoe ze gebruikt worden: 
+
+| Label           | Betekenis                          | Voorbeeldgebruik                       | 
+| :-------------  | :--------------------------------- | :------------------------------------- | 
+| **informeel**   | Niet geschikt voor formele context | "bakske" (voor auto)                   | 
+| **West-Vlaams** | Typisch voor West-Vlaanderen       | "goeste" (zin, trek)                   | 
+| **ouderwets**   | In onbruik geraakt                 | "koddig"                               | 
+| **technisch**   | Gebruikt in vakjargon              | "router"                               | 
+| **sarcastisch** | Op ironische toon gebruikt         | "held" (voor iemand die iets dom doet) |
+
+## Regels voor labelgebruik 
+
+- Gebruik labels **consistent** en volgens bestaande richtlijnen. 
+- **Twijfel je?** Laat het label weg en overleg met een eindredacteur. 
+- **Controleer eerst** of een label al bestaat, om dubbele en tegenstrijdige labels te vermijden. 
+- **Maak nooit zelf nieuwe labels aan**, dit gebeurt enkel via de bevoegde personen. 
+- **herbekijk regelmatig** of oudere labels nog kloppen. Taalgebruik is iets dat continu evolueert. 
+
+## Onderhoud 
+
+Eindredacteurs en administrators zorgen dat het systeem up-to-date blijkt. 
+Ze controleren op fouten en dubbels, en beheren nieuwe labels. 
+Elke verandering in het labelaanbod word ook in deze documentatie opgenomen indien nodig.
+
+## Veelgestelde vragen (FAQ)
+
+- **Ik mis een label. Wat nu?** -> Vraag het aan een adminstrator zodat hij/zij het nodige kan doen. 
+- **Kan ik een fout label verwijderen?** -> Beperkt? Meld het aan een eindredacteur of administrator. 
+- **Ziet de gebruiker elk label?** -> Ja een gebruiker kan elk gekoppeld label bekijken. 
+- **Mag ik zelf een label aanmaken?** -> Nee, dat is voorbehouden aan beheerders. 
+
+## Vragen of hulp nodig? 
+
+Contacteer een administrator en of eindredacteur of plaats een bericht op het redacteursforum. Zo blijf je nooit met vragen zitten.

--- a/docs/artikelen/labelsysteem.md
+++ b/docs/artikelen/labelsysteem.md
@@ -2,14 +2,14 @@
 
 Het labelsysteem is een kernonderdeel van het Vlaams woordenboek. 
 Het helpt om woorden niet alleen te beschrijven, maar ook te kaderen in gebruik, toon, plaats en tijd.
-Deze documentatie is er voor idereen die aan het woordenboek meewerkt: redacteurs, eindredacteurs, administrators en ontwikkelaars. 
-Het doel is helderheid en uniformiteit in het gebruik van labels, zodat de inhoud betouwbaar en bruikbaar blijft. 
+Deze documentatie is er voor iedereen die aan het woordenboek meewerkt: redacteurs, eindredacteurs, administrators en ontwikkelaars. 
+Het doel is helderheid en uniformiteit brengen in het gebruik van labels, zodat de inhoud betouwbaar en bruikbaar blijft. 
 
 ## Wat doet het labelsysteem? 
 
 Met labels geef je extra informatie over een woord. 
 Ze kunnen aanduiden of een woord formeel of informeel is, typisch voor een bepaalde regio, vooral vroeger gebruikt werd, of specifiek is voor een bepaald vakgebied. 
-Ook de gebruikssituatie zoals ironisch of kindertaal kan gelabeld worden. Een woord mag gerust meerdere lebels tegelijk krijgen. 
+Ook de gebruikssituatie zoals ironisch, aanstootgeven of kindertaal kan gelabeld worden. Een woord mag gerust meerdere labels tegelijk krijgen. 
 
 ## Wie mag wat? 
 
@@ -27,7 +27,7 @@ Hieronder zie je welke rechten hebben binnen het beheer van het labelsysteem:
 Als je een woord invoert of bewerkt, zie je een veld 'Labels'. Je kunt daar typen om een label te zoeken, of een selectie maken uit de lijst.
 Geselecteerde labels verschijnen als visuele 'badges'.
 Je kunt ze eenvoudig verwijderen met een klik op het kruisje. 
-Als alles klaar is, kklik je op "Oplsaan", "Bevestigen" op "Volgende". 
+Als alles klaar is, klik je op "Opslaan", "Bevestigen" op "Volgende". 
 
 ## Voorbeelden in de interface 
 
@@ -52,20 +52,21 @@ Hieronder een overzicht van enkele voorbeeldlabels ter illustratie en hoe ze geb
 - Gebruik labels **consistent** en volgens bestaande richtlijnen. 
 - **Twijfel je?** Laat het label weg en overleg met een eindredacteur. 
 - **Controleer eerst** of een label al bestaat, om dubbele en tegenstrijdige labels te vermijden. 
-- **Maak nooit zelf nieuwe labels aan**, dit gebeurt enkel via de bevoegde personen. 
-- **herbekijk regelmatig** of oudere labels nog kloppen. Taalgebruik is iets dat continu evolueert. 
+- **Maak nooit zelf nieuwe labels aan**, dit gebeurt enkel via de bevoegde personen.
+- **Mis je een label?**, meld dat aan de bevoegde persoon.
+- **Herbekijk regelmatig** of oudere labels nog kloppen. Taalgebruik is iets dat continu evolueert. 
 
 ## Onderhoud 
 
 Eindredacteurs en administrators zorgen dat het systeem up-to-date blijkt. 
 Ze controleren op fouten en dubbels, en beheren nieuwe labels. 
-Elke verandering in het labelaanbod word ook in deze documentatie opgenomen indien nodig.
+Elke verandering in het labelaanbod wordt ook in deze documentatie opgenomen indien nodig.
 
 ## Veelgestelde vragen (FAQ)
 
 - **Ik mis een label. Wat nu?** -> Vraag het aan een adminstrator zodat hij/zij het nodige kan doen. 
-- **Kan ik een fout label verwijderen?** -> Beperkt? Meld het aan een eindredacteur of administrator. 
-- **Ziet de gebruiker elk label?** -> Ja een gebruiker kan elk gekoppeld label bekijken. 
+- **Kan ik een verkeerd label verwijderen?** -> Meld het aan een eindredacteur of administrator. 
+- **Ziet de gebruiker elk label?** -> Ja, een gebruiker kan elk gekoppeld label bekijken. 
 - **Mag ik zelf een label aanmaken?** -> Nee, dat is voorbehouden aan beheerders. 
 
 ## Vragen of hulp nodig? 


### PR DESCRIPTION
Deze pull request voegt de beginselen van de documentatie toe voor het labelsysteem dat gehanteerd word bij de woordenboek artikelen. In mijn beperkte kennis en optiek omtrent taalkundige kwesties. Dekt die grotendeels het labelsysteem wel. 

**Opgelet:** Na het mergen van deze PR. Zou de url naar de documentatie moeten verworven worden met het labelsysteem in de beheersconsole van het woordenboek. 
